### PR TITLE
Make OpenBLAS_ROOT_DIR configurable

### DIFF
--- a/CMakeModules/FindOpenBLAS.cmake
+++ b/CMakeModules/FindOpenBLAS.cmake
@@ -9,6 +9,7 @@ SET(Open_BLAS_INCLUDE_SEARCH_PATHS
   /usr/local/OpenBLAS/include
   $ENV{OpenBLAS_HOME}
   $ENV{OpenBLAS_HOME}/include
+  ${OpenBLAS_ROOT_DIR}/include
 )
 
 SET(Open_BLAS_LIB_SEARCH_PATHS
@@ -26,6 +27,7 @@ SET(Open_BLAS_LIB_SEARCH_PATHS
         $ENV{OpenBLAS}/lib
         $ENV{OpenBLAS_HOME}
         $ENV{OpenBLAS_HOME}/lib
+        ${OpenBLAS_ROOT_DIR}/lib
  )
 
 FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})


### PR DESCRIPTION
This makes it possible to specify `-DOpenBLAS_ROOT_DIR=/usr/local/opt/openblas` at the cmake command line. This happens to be the path where openblas is on my machine.