### PR TITLE
This should fix '/usr/bin/ld: cannot find -lopenblas' in #85

### DIFF
--- a/src/MS/CMakeLists.txt
+++ b/src/MS/CMakeLists.txt
@@ -42,7 +42,6 @@ if(HAVE_CUDA)
         ${WCSLIB_LIBRARIES}
         ${GLIB_PKG_LIBRARIES}
         ${LIBGFORTRAN_LIBRARIES}
-        -lopenblas
         -lgfortran
         -lpthread
         -lm


### PR DESCRIPTION
Removing `-lopenblas` in `src/MS/CMakeLists.txt` in order to fix #85.

