### PR TITLE
Fix incorrect Gaus scaling with half pi

### DIFF
--- a/src/lib/Radio/predict.c
+++ b/src/lib/Radio/predict.c
@@ -215,7 +215,7 @@ gaussian_contrib(void*dd, double u, double v, double w) {
   /* Fourier TF is normalized with integrated flux,
     so to get the peak value right, scale the flux */
   //return 0.5*exp(-(ut*ut+vt*vt))/sqrt(2.0*a*b);
-  return M_PI_2*exp(-(ut*ut+vt*vt));
+  return exp(-(ut*ut+vt*vt));
 }
 
 complex double

--- a/src/lib/Radio/predict.c
+++ b/src/lib/Radio/predict.c
@@ -215,7 +215,7 @@ gaussian_contrib(void*dd, double u, double v, double w) {
   /* Fourier TF is normalized with integrated flux,
     so to get the peak value right, scale the flux */
   //return 0.5*exp(-(ut*ut+vt*vt))/sqrt(2.0*a*b);
-  return exp(-(ut*ut+vt*vt));
+  return exp(-2.0*M_PI*M_PI*(ut*ut+vt*vt));
 }
 
 complex double

--- a/src/lib/Radio/predict_model.cu
+++ b/src/lib/Radio/predict_model.cu
@@ -347,7 +347,7 @@ gaussian_contrib__(int *dd, float u, float v, float w) {
   ut=a*(cosph*up-sinph*vp);
   vt=b*(sinph*up+cosph*vp);
 
-  return make_cuDoubleComplex((double)(0.5f*M_PI*expf(-(ut*ut+vt*vt))),0.0);
+  return make_cuDoubleComplex((double)(expf(-2.0*M_PI*M_PI*(ut*ut+vt*vt))),0.0);
 }
 
 

--- a/src/lib/Radio/readsky.c
+++ b/src/lib/Radio/readsky.c
@@ -409,8 +409,8 @@ read_sky_cluster(const char *skymodel, const char *clusterfile, clus_source_t **
          fprintf(stderr,"%s: %d: no free memory\n",__FILE__,__LINE__);
          exit(1);
        } 
-       exg->eX=2.0*eX; /* scale by 2 */
-       exg->eY=2.0*eY;
+       exg->eX=eX / (2.0*(sqrt(2.0*log(2.0)))); /* convert fwhm to sigma */
+       exg->eY=eY / (2.0*(sqrt(2.0*log(2.0))));
        exg->eP=eP;
        /* negate angles */
        exg->cxi=cos(xi);


### PR DESCRIPTION
Sagecal simulates Gaussian sources with an integrated flux density that is ~1.6 times too high. It appears that this is caused by a "half pi" factor that is in the Gaussian prediction unnecessary.