### PR TITLE
Spatialreg per direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,18 @@ Specific options :
 
 ```-Q``` : can change the type of polynomial used (```-Q 2``` gives Bernstein polynomials).
 
-```-r 5``` : regularization factor is 5.0.
+```-r 5``` : regularization factor is 5.0. See ```-G``` option below for regularization per direction.
 
-```-G textfile```: each cluster can have a different regularization factor, instead of using ```-r``` option when the regularization is the same for all clusters.
+```-G textfile```: each cluster can have a different regularization factor, instead of using ```-r``` option when the regularization is the same for all clusters. The text file format is as follows: each row should have the cluter_id, hybrid count (= same as in the cluster file), spectral regularization, and spatial regularization, e.g.,
+
+```
+# cluster_id hybrid_factor spetral_reg spatial_reg
+-1 1 5.0 3.0
+2 4 1.0 2.0
+...
+```
+
+Note that lines starting with '#' are comments.
 
 ```-N 1```: enable **stochastic** calibration (minibatches of data), combined with options ```-M```, ```-w``` and ```-u```.
 
@@ -176,7 +185,7 @@ Spatial regularization (with distributed multi-directional calibration) enables 
 
 ```-X L2 penalty,L1 penalty,model order,FISTA iterations,update cadence``` : For example ```-X 0.01,1e-4,3,40,10``` will use 0.01 as the L2 penalty and 1e-4 as the L1 penalty for solving an elastic net regression to build a spatial model. The model will have 3x3=9 spatial basis functions. The elastic net model will be found using 40 FISTA iterations. The spatial model will be updated at every 10 ADMM iterations.
 
-```-u alpha``` : The regularization factor for the spatial constraint while solving the consensus problem. This factor is scaled according to the value of rho given to each cluster (see section 5 above). The cluster with the highest rho value will have the value of alpha given by ```-u```.
+```-u alpha``` : The regularization factor for the spatial constraint while solving the consensus problem. Note that by using the  ```-G``` option, you can define regularization factors for each cluster.
 
 
 ### 6) Solution format

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ Optionally: Make sure your machine has (1/2 working NVIDIA GPU cards or Intel Xe
 Recommended usage: (with GPUs)
 
 ```
-sagecal -d my_data.MS -s my_skymodel -c my_clustering -n no.of.threads -t 60 -p my_solutions -e 3 -g 2 -l 10 -m 7 -w 1 -b 1
+sagecal_gpu -d my_data.MS -s my_skymodel -c my_clustering -n no.of.threads -t 60 -p my_solutions -e 3 -g 2 -l 10 -m 7 -w 1 -b 1
 ```
+
+Replace ```sagecal_gpu``` with ```sagecal``` if you have a CPU only build.
 
 Use your solution interval (-t 60) so that its big enough to get a decent solution and not too big to make the parameters vary too much. (about 20 minutes per solution is reasonable).
 
@@ -131,7 +133,7 @@ Use ```-N 1``` combined with options for ```-M```,```-w``` (see also section 4 b
 
 ### 4) Distributed calibration
 
-Use mpirun to run sagecal-mpi, example:
+Use mpirun to run sagecal-mpi, (or ```sagecal-mpi_gpu``` for GPU version) for example:
 ```
  mpirun  -np 11 -hostfile ./machines --map-by node --cpus-per-proc 8 
  --mca yield_when_idle 1 -mca orte_tmpdir_base /scratch/users/sarod 

--- a/README.md
+++ b/README.md
@@ -154,12 +154,21 @@ Specific options :
 
 ```-r 5``` : regularization factor is 5.0. See ```-G``` option below for regularization per direction.
 
-```-G textfile```: each cluster can have a different regularization factor, instead of using ```-r``` option when the regularization is the same for all clusters. The text file format is as follows: each row should have the cluter_id, hybrid count (= same as in the cluster file), spectral regularization, and spatial regularization, e.g.,
+```-G textfile```: each cluster can have a different regularization factor, instead of using ```-r``` option (and ```-u``` option) when the regularization is the same for all clusters. The text file format is as follows: each row should have the cluter_id, hybrid count (= same as in the cluster file), spectral regularization, and (optionally) spatial regularization, e.g.,
 
 ```
 # cluster_id hybrid_factor spetral_reg spatial_reg
 -1 1 5.0 3.0
 2 4 1.0 2.0
+...
+```
+
+It is also possible to only use spectral regularization, for example,
+
+```
+# cluster_id hybrid_factor spetral_reg
+-1 1 5.0
+2 4 1.0
 ...
 ```
 

--- a/src/MPI/main.cpp
+++ b/src/MPI/main.cpp
@@ -66,8 +66,8 @@ print_help(void) {
    cout << "-A ADMM iterations: default " <<Data::Nadmm<< endl;
    cout << "-P consensus polynomial terms: default " <<Data::Npoly<< endl;
    cout << "-Q consensus polynomial type (0,1,2,3): default " <<Data::PolyType<< endl;
-   cout << "-r regularization factor: default " <<Data::admm_rho<< endl;
-   cout << "-G regularization factor of each cluster (text file instead of -r, has to match _exactly_ the cluster file's first 2 columns): default : None" << endl;
+   cout << "-r spectral regularization factor, can be overridden by using -G option: default " <<Data::admm_rho<< endl;
+   cout << "-G regularization factors (both spectral and spatial) of each cluster (using text file instead of using -r and -u, has to match _exactly_ the cluster file's first 2 columns): default : None" << endl;
    cout << "-C if >0, adaptive update of regularization factor: default "<<Data::aadmm<< endl;
    cout << "-x exclude baselines length (lambda) lower than this in calibration : default "<<Data::min_uvcut << endl;
    cout << "-y exclude baselines length (lambda) higher than this in calibration : default "<<Data::max_uvcut << endl;
@@ -95,7 +95,7 @@ print_help(void) {
    cout << "-N epochs, if >0, use stochastic calibration: default "<<Data::stochastic_calib_epochs<< endl;
    cout << "-M minibatches, must be >0, split data to this many minibatches: default "<<Data::stochastic_calib_minibatches<< endl;
    cout << "-w mini-bands, must be >0, split channels to this many mini-bands for bandpass calibration: default "<<Data::stochastic_calib_bands<< endl;
-   cout << "-u alpha, must be >0, alpha is the regularization factor used in passing global Z to local value and in spatial regularization: default "<<Data::federated_reg_alpha<< endl;
+   cout << "-u alpha, must be >0, alpha is the regularization factor used in passing global Z to local value and in spatial regularization. Can be overridden by using -G option, default "<<Data::federated_reg_alpha<< endl;
    cout << "-X lambda,mu,n0,fista_maxiter,cadence: if defined, enable spatial regularization: (lambda: L2, mu: L1, n0: model order with n0^2 modes, fista_maxiter: FISTA iterations, cadence: update cadence):  default:"<<Data::spatialreg<<endl;
    cout <<"Report bugs to <sarod@users.sf.net>"<<endl;
 }

--- a/src/MS/fullbatch_mode.cpp
+++ b/src/MS/fullbatch_mode.cpp
@@ -141,6 +141,7 @@ run_fullbatch_calibration(void) {
   }
    /* if simulation mode, solution file is given check if ignore file
       is also given */
+  /* FIXME: ignore list parsing need to be improved, also done before reading the sky model */
   int *ignorelist=0;
   if (Data::DoSim && solfile) {
     if ((ignorelist=(int*)calloc((size_t)M,sizeof(int)))==0) {

--- a/src/lib/Dirac/consensus_poly.c
+++ b/src/lib/Dirac/consensus_poly.c
@@ -81,6 +81,11 @@ setup_polynomials(double *B, int Npoly, int Nf, double *freqs, double freq0, int
    /* Bernstein polynomials */
    int idmax=my_idamax(Nf, freqs, 1);
    int idmin=my_idamin(Nf, freqs, 1);
+   /* sanity check */
+   if (idmax<1) idmax=1;
+   if (idmax>Nf) idmax=Nf;
+   if (idmin<1) idmin=1;
+   if (idmin>Nf) idmin=Nf;
    double fmax=freqs[idmax-1];
    double fmin=freqs[idmin-1];
    double *fact; /* factorial array */

--- a/src/lib/Radio/Dirac_radio.h
+++ b/src/lib/Radio/Dirac_radio.h
@@ -102,19 +102,33 @@ read_solutions(FILE *sfp,double *p,clus_source_t *carr,int N,int M);
 extern int
 update_ignorelist(const char *ignfile, int *ignlist, int M, clus_source_t *carr);
 
-/* read ADMM regularization factor per cluster from text file, format:
- cluster_id  hybrid_parameter admm_rho
+/* read ADMM regularization factor per cluster from text file:
+ *
+ *
+ * format without spatial regularization:
+#cluster_id  hybrid_parameter admm_rho
  ...
  ...
  (M values)
+ admm_rho : can be 0 to ignore consensus, just normal calibration
+# end file
+
+ format with spatial regularization:
+#cluster_id  hybrid_parameter admm_rho spatial_alpha
+ ...
+ ...
+ (M values)
+# end file
+
  and store it in array arho : size Mtx1, taking into account the hybrid parameter
  also in array arhoslave : size Mx1, without taking hybrid params into account
 
- admm_rho : can be 0 to ignore consensus, just normal calibration
+ if spatialreg>0, also read spatial regularization factors (read M and store Mt values)
+ alpha: Mtx1 spatial regularization values
 */
 
 extern int
-read_arho_fromfile(const char *admm_rho_file,int Mt,double *arho, int M, double *arhoslave);
+read_arho_fromfile(const char *admm_rho_file,int Mt,double *arho, int M, double *arhoslave, int spatialreg, double *alpha);
 
 /****************************** predict.c ****************************/
 /************* extended source contributions ************/


### PR DESCRIPTION
Enable specification of regularization factors per direction in spatial regularization, so both spectral and spatial regularization factors can be specified in a text file, see -G option
